### PR TITLE
Update last_reboot_time.sh

### DIFF
--- a/UEM-Samples/Sensors/macOS/Custom Attributes/last_reboot_time.sh
+++ b/UEM-Samples/Sensors/macOS/Custom Attributes/last_reboot_time.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-lastreboot=$(/usr/bin/last reboot | head -n1 | cut -d ' ' -f30-)
-echo $lastreboot
-
-#Tue Sep 27 15:04
-#Can be formatted differently or to an integer
-
-#also try `uptime`
+# Use "Date Time" as the data type for the sensor. 
+lastreboot=$(date -jf "%s" "$(sysctl kern.boottime | awk -F'[= |,]' '{print $6}')" +"%Y-%m-%dT%TZ")
+echo "${lastreboot}"


### PR DESCRIPTION
Captures the date and time of the last reboot in the format that WS1 expects, and can be used with Date Time as the data type. 

Signed-off-by: Patrick Gallagher <patgmac@gmail.com>